### PR TITLE
Add option to save working sets in the workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- Add option to save working sets in the workspace folder.
+
 ## [1.3.1] - 08/21/2020
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "working-sets",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2202,6 +2202,11 @@
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
 			}
+		},
+		"fs": {
+			"version": "0.0.1-security",
+			"resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+			"integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
 		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/bernardop/vscode-working-sets"
   },
-  "version": "1.3.1",
+  "version": "1.4.0",
   "publisher": "bernardop",
   "engines": {
     "vscode": "^1.43.0"
@@ -247,6 +247,11 @@
           "type": "boolean",
           "default": false,
           "description": "Show confirmation notifications after every action"
+        },
+        "workingSets.saveWorkingSetsInProject": {
+          "type": "boolean",
+          "default": false,
+          "description": "Save (and restore) working sets locally in the opened project instead of globally in VSCode"
         }
       }
     }


### PR DESCRIPTION
I have added an option to store the working sets locally in `.vscode` directory. This way they can be version-controlled or easily copied between different machines.